### PR TITLE
Changed avatar url

### DIFF
--- a/contribs.html
+++ b/contribs.html
@@ -170,7 +170,7 @@
     {{each data}}
       {{if login != "invalid-email-address"}}  
         <div style="clear:both; margin: 8px; height: 80px; width: 600px;">
-            <img src="http://gravatar.com/avatar/${gravatar_id}" alt="${name || login}" style="float:left;" />
+            <img src="${avatar_url}" alt="${name || login}" style="float:left; width:80px;" />
             <div style="float:left; margin-left: 12px;">
               <h3>#${$index + 1} (${contributions} commits)</h3>
               <h2>${name ? name.replace(" ", " '" + login + "' ") + "!" : login}</h2>


### PR DESCRIPTION
From [GitHub API deprecations](http://developer.github.com/v3/#deprecations):

> `gravatar_url` is being deprecated in favor of `avatar_url` for all responses that include users or orgs. A default size is no longer included in the URL.

This will fall back to github's identicon avatars if user doesn't have gravatar.
